### PR TITLE
Created a photos module to update coverage delivery href

### DIFF
--- a/photos/__init__.py
+++ b/photos/__init__.py
@@ -1,0 +1,14 @@
+from flask import current_app as app
+
+
+def set_photo_coverage_href(coverage, planning_item):
+    if app.config.get('PHOTO_URL') and \
+            coverage['planning']['g2_content_type'] == 'picture' and \
+            coverage['workflow_status'] == 'completed':
+        slugline = coverage.get('planning', {}).get('slugline', planning_item.get('slugline'))
+        q = '{"DateRange":[{"Start":"%s"}],"DateCreatedFilter":"true"}' % coverage['scheduled'][:10]
+        return '{}"{}"?q={}'.format(app.config.get('PHOTO_URL'), slugline, q)
+
+
+def init_app(app):
+    app.set_photo_coverage_href = set_photo_coverage_href

--- a/settings.py
+++ b/settings.py
@@ -11,6 +11,7 @@ BLUEPRINTS.append('newsroom.am_news')
 
 INSTALLED_APPS = [
     'instrumentation',
+    'photos',
     'newsroom.am_news'
 ]
 


### PR DESCRIPTION
- Custom module to set the delivery href for completed photo coverages
- Depends on https://github.com/superdesk/newsroom/pull/545
- Requires a `PHOTO_URL` key in settings for Base Url for photos: i.e. `https://photos.aap.com.au/search/`