### PR TITLE
fix: Menus showing alternate Factcheck links

### DIFF
--- a/server/theme/header_nav_links.html
+++ b/server/theme/header_nav_links.html
@@ -1,14 +1,23 @@
 <div class="main navbar navbar-header_nav_links d-flex align-items-center justify-content-center">
-    {% for group in range(0, 10) %}
-        {% for nav in sidenavs(request.blueprint)|selectattr("group", "equalto", group) %}
-            {% if request.endpoint != nav.endpoint and nav.group != 1 %}
+    {% set fns = namespace(factcheck_shown=false) %}
+    {% for nav in sidenavs(request.blueprint)|sort(attribute='group') %}
+        {% set is_active_endpoint = request.endpoint == nav.endpoint %}
+        {% set is_group_one = nav.group == 1 %}
+        {% set is_factcheck = nav.get('name') == 'FactCheck' %}
+
+        {% if not is_active_endpoint and not is_group_one %}
+            {% if not is_factcheck or not fns.factcheck_shown %}
                 <div>
                     <a href="{{ url_for(nav.endpoint) if nav.endpoint else nav.url }}"
-                       {% if nav.url %}target="_blank"{% endif %}
-                    >{{ gettext(nav.name) }}
+                       {% if nav.url %}target="_blank"{% endif %}>
+                        {{ gettext(nav.name) }}
                     </a>
                 </div>
             {% endif %}
-        {% endfor %}
+        {% endif %}
+
+        {% if is_factcheck %}
+            {% set fns.factcheck_shown = true %}
+        {% endif %}
     {% endfor %}
 </div>

--- a/server/theme/layout.html
+++ b/server/theme/layout.html
@@ -1,29 +1,24 @@
 {% extends "base_layout.html" %}
 
 {% block default_navs %}
-    {% for nav in sidenavs_by_names(['Home', 'Saved/Watched Items'], request.blueprint) %}
-        {% include "sidenav_icon_no_url.html" %}
-    {% endfor %}
-    <div class="divider"></div>
-    {% set ns = namespace(factcheck_shown=false) %}
-    {% for nav in sidenavs_by_group(0, request.blueprint) %}
-        {% if nav.get('name') != 'Home' %}
-            {% include "sidenav_icon_no_url.html" %}
-        {% endif %}
-        {% if nav.get('name') == 'FactCheck' %}
-            {% set ns.factcheck_shown = true %}
-        {% endif %}
-    {% endfor %}
-    <div class="divider"></div>
-    {% for nav in sidenavs_by_group(2, request.blueprint) %}
-        {% if nav.get('name') != 'FactCheck' %}
-            {% include "sidenav_icon_no_url.html" %}
-        {% else %}
-            {% if ns.factcheck_shown == false %}
-                {% include "sidenav_icon_no_url.html" %}
+    {% set fns = namespace(factcheck_shown=false) %}
+    {% for group in range(0, 10) %}
+        {% for nav in sidenavs(request.blueprint)|selectattr("group", "equalto", group) %}
+            {% if group > 0 and loop.first and loop.length %}
+                <li class="sidenav__separator" role="presentation">
+                    <span class="separator__dot" aria-hidden="true"></span>
+                    <span class="separator__dot" aria-hidden="true"></span>
+                    <span class="separator__dot" aria-hidden="true"></span>
+                    <span class="separator__dot" aria-hidden="true"></span>
+                </li>
             {% endif %}
-        {% endif %}
+            {% set is_factcheck = nav.get('name') == 'FactCheck' %}
+            {% if not is_factcheck or not fns.factcheck_shown %}
+                {% include "sidenav_icon.html" %}
+            {% endif %}
+            {% if is_factcheck %}
+                {% set fns.factcheck_shown = true %}
+            {% endif %}
+        {% endfor %}
     {% endfor %}
 {% endblock %}
-
-{% block custom_content_style %}contentWrap--small-header{% endblock %}


### PR DESCRIPTION
Depending on the company permissions the FactCheck link should be to Newsroom if permissioned and the public web site if not!